### PR TITLE
Add transaction inquiry functionality to ZarinPalDriver

### DIFF
--- a/src/drivers/zarinpal/enums/urls.enum.ts
+++ b/src/drivers/zarinpal/enums/urls.enum.ts
@@ -50,5 +50,21 @@ export enum ZarinpalUrls {
    * @type {string}
    * @memberof ZarinpalUrls
    */
-  SANDBOX_REQUEST_PAGE = 'https://sandbox.zarinpal.com/pg/StartPay/'
+  SANDBOX_REQUEST_PAGE = 'https://sandbox.zarinpal.com/pg/StartPay/',
+
+  /**
+   * URL for inquerying a payment transaction.
+   *
+   * @type {string}
+   * @memberof ZarinpalUrls
+   */
+  INQUERY = 'https://payment.zarinpal.com/pg/v4/payment/inquiry.json',
+
+  /**
+   * URL for inquerying a payment transaction in the sandbox environment.
+   *
+   * @type {string}
+   * @memberof ZarinpalUrls
+   */
+  SANDBOX_INQUERY = 'https://sandbox.zarinpal.com/pg/v4/payment/inquiry.json'
 }

--- a/src/drivers/zarinpal/interfaces/requests.interface.ts
+++ b/src/drivers/zarinpal/interfaces/requests.interface.ts
@@ -43,6 +43,18 @@ export interface TransactionVerifyInputZp extends Pick<TransactionCreateInputZp,
 }
 
 /**
+ * Represents the input structure for inquiring a transaction with ZarinPal.
+ * Inherits property 'merchant_id' from TransactionCreateInputZp.
+ *
+ * @interface TransactionInquiryInputZp
+ * @extends {Pick<TransactionCreateInputZp, "merchant_id">}
+ * @property {string} authority Transaction authority.
+ */
+export interface TransactionInquiryInputZp extends Pick<TransactionCreateInputZp, 'merchant_id'> {
+  authority: string
+}
+
+/**
  * Represents the error structure for ZarinPal transactions.
  *
  * @interface TransactionErrorZp
@@ -60,7 +72,7 @@ export interface TransactionErrorZp {
   message: string
 
   validations: Record<keyof TransactionCreateInputZp, string>[]
-  
+
   type?: 'payment' | 'network' | 'api'
 }
 
@@ -123,5 +135,34 @@ export type TransactionVerifyResponseZp =
         ref_id: number
         fee_type: string
         fee: number
+      }
+    }
+
+/**
+ * Represents the response structure for inquiring a transaction with ZarinPal.
+ *
+ * @type TransactionInquiryResponseZp
+ * @property {boolean} isError Indicates if there's an error in the response.
+ * @property {object} data Data related to the inquired transaction if successful.
+ * @property {number} data.code Transaction code.
+ * @property {string} data.message Transaction message.
+ * @property {string} data.card_hash Card hash for the transaction.
+ * @property {string} data.card_pan Card PAN for the transaction.
+ * @property {number} data.ref_id Reference ID for the transaction.
+ * @property {string} data.fee_type Fee type for the transaction.
+ * @property {number} data.fee Fee amount for the transaction.
+ * @property {TransactionErrorZp} error Error details if an error occurred.
+ */
+export type TransactionInquiryResponseZp =
+  | {
+      isError: true
+      error: TransactionErrorZp
+    }
+  | {
+      isError: false
+      data: {
+        status: 'PAID' | 'VERIFIED' | 'IN_BANK' | 'FAILED' | 'REVERSED'
+        code: number
+        message: string
       }
     }


### PR DESCRIPTION
This update introduces a new method for inquiring about payment transactions in the ZarinPalDriver. The inquiry method allows users to check the status of a transaction using its unique authority key.

Additionally, new interfaces for transaction inquiry requests and responses have been defined to ensure type safety and clarity. The error handling has been enhanced to differentiate between network errors and API errors, providing more informative feedback to users.

The URLs for the inquiry endpoints have also been added to the ZarinpalUrls enum, ensuring that the driver can seamlessly switch between sandbox and production environments.