### PR TITLE
Add custom domain support to ZarinPalDriver

### DIFF
--- a/examples/custom-domain-example.ts
+++ b/examples/custom-domain-example.ts
@@ -1,0 +1,67 @@
+import { ZarinPalDriver } from '../src/drivers/zarinpal'
+
+// Initialize the ZarinPal driver
+const zarinpal = new ZarinPalDriver()
+
+// Basic configuration
+zarinpal.setToken('your-merchant-id')
+zarinpal.setTimeout(15000) // 15 seconds timeout
+
+// NEW: Set custom domain (this is optional)
+// If not set, it will fallback to default ZarinPal domains
+zarinpal.setCustomDomain('api.yourgateway.com')
+
+// Example usage scenarios:
+
+async function exampleWithCustomDomain() {
+  // When custom domain is set, all API calls will use the custom domain
+  
+  // This will make a request to: https://api.yourgateway.com/pg/v4/payment/request.json
+  const result = await zarinpal.request({
+    amount: 10000, // 100 IRR (amounts are in Rials)
+    description: 'Payment for order #123',
+    callback_url: 'https://yoursite.com/payment/callback'
+  })
+
+  if (!result.isError) {
+    console.log('Payment URL:', result.data.url) 
+    // This will be: https://api.yourgateway.com/pg/StartPay/{authority}
+  }
+}
+
+async function exampleWithDefaultDomain() {
+  // Create a new instance without custom domain
+  const defaultZarinpal = new ZarinPalDriver()
+  defaultZarinpal.setToken('your-merchant-id')
+  
+  // This will use default ZarinPal URLs
+  const result = await defaultZarinpal.request({
+    amount: 10000,
+    description: 'Payment for order #123',
+    callback_url: 'https://yoursite.com/payment/callback'
+  })
+  
+  if (!result.isError) {
+    console.log('Payment URL:', result.data.url)
+    // This will be: https://www.zarinpal.com/pg/StartPay/{authority}
+  }
+}
+
+async function exampleWithSandbox() {
+  // Custom domain also works with sandbox mode
+  zarinpal.setCustomDomain('sandbox.yourgateway.com')
+  
+  // This will make a request to: https://sandbox.yourgateway.com/pg/v4/payment/request.json
+  const result = await zarinpal.request({
+    amount: 10000,
+    description: 'Test payment',
+    callback_url: 'https://yoursite.com/payment/callback'
+  }, true) // true = sandbox mode
+  
+  if (!result.isError) {
+    console.log('Sandbox Payment URL:', result.data.url)
+    // This will be: https://sandbox.yourgateway.com/pg/StartPay/{authority}
+  }
+}
+
+export { exampleWithCustomDomain, exampleWithDefaultDomain, exampleWithSandbox } 

--- a/src/drivers/zarinpal/__tests__/zarinpal.spec.ts
+++ b/src/drivers/zarinpal/__tests__/zarinpal.spec.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { ZarinPalDriver } from '../zarinpal'
 import { TransactionCreateInputZp } from '../interfaces/requests.interface'
 import { zarinPalErrors } from '../enums/errors.enum'
+import { ZarinpalUrls } from '../enums/urls.enum'
 
 jest.mock('axios')
 const mockedAxios = axios as jest.Mocked<typeof axios>
@@ -87,7 +88,8 @@ describe('ZarinPalDriver', () => {
       error: {
         code: -9,
         message: zarinPalErrors['-9'],
-        validations: []
+        validations: [],
+        type: 'payment'
       },
       isError: true
     }
@@ -97,5 +99,172 @@ describe('ZarinPalDriver', () => {
     const response = await driver.request(mockData)
 
     expect(response).toEqual(errorResponse)
+  })
+
+  describe('Custom Domain Support', () => {
+    it('should set custom domain correctly', () => {
+      const customDomain = 'api.example.com'
+      driver.setCustomDomain(customDomain)
+      expect(driver['customDomain']).toBe(customDomain)
+    })
+
+    it('should clean domain input by removing protocol and trailing slash', () => {
+      driver.setCustomDomain('https://api.example.com/')
+      expect(driver['customDomain']).toBe('api.example.com')
+    })
+
+    it('should throw error for invalid domain', () => {
+      expect(() => driver.setCustomDomain('')).toThrowError('invalid domain parameter')
+      expect(() => driver.setCustomDomain(null as any)).toThrowError('invalid domain parameter')
+    })
+
+    it('should use custom domain for API requests', async () => {
+      const customDomain = 'api.example.com'
+      driver.setCustomDomain(customDomain)
+
+      const mockData: TransactionCreateInputZp = {
+        amount: 1000,
+        description: 'Test transaction',
+        callback_url: 'https://example.com/callback'
+      }
+
+      const expectedResponse: any = {
+        data: {
+          code: 1000,
+          message: '',
+          fee: 100,
+          url: '',
+          authority: 'xx',
+          fee_type: ''
+        },
+        errors: {
+          code: 0,
+          message: 'Transaction created successfully',
+          validations: []
+        },
+        isError: false
+      }
+
+      mockedAxios.post.mockResolvedValue({ data: expectedResponse })
+
+      await driver.request(mockData)
+
+      // Verify that the custom domain URL was used
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://api.example.com/pg/v4/payment/request.json',
+        expect.any(Object),
+        expect.any(Object)
+      )
+    })
+
+    it('should use custom domain for payment page URL', async () => {
+      const customDomain = 'api.example.com'
+      driver.setCustomDomain(customDomain)
+
+      const mockData: TransactionCreateInputZp = {
+        amount: 1000,
+        description: 'Test transaction',
+        callback_url: 'https://example.com/callback'
+      }
+
+      const expectedResponse: any = {
+        data: {
+          code: 1000,
+          message: '',
+          fee: 100,
+          url: '',
+          authority: 'test-authority',
+          fee_type: ''
+        },
+        errors: {
+          code: 0,
+          message: 'Transaction created successfully',
+          validations: []
+        },
+        isError: false
+      }
+
+      mockedAxios.post.mockResolvedValue({ data: expectedResponse })
+
+      const response = await driver.request(mockData)
+
+      // Verify that the custom domain payment page URL was used
+      expect(response.data.url).toBe('https://api.example.com/pg/StartPay/test-authority')
+    })
+
+    it('should fallback to default URLs when no custom domain is set', async () => {
+      const mockData: TransactionCreateInputZp = {
+        amount: 1000,
+        description: 'Test transaction',
+        callback_url: 'https://example.com/callback'
+      }
+
+      const expectedResponse: any = {
+        data: {
+          code: 1000,
+          message: '',
+          fee: 100,
+          url: '',
+          authority: 'xx',
+          fee_type: ''
+        },
+        errors: {
+          code: 0,
+          message: 'Transaction created successfully',
+          validations: []
+        },
+        isError: false
+      }
+
+      mockedAxios.post.mockResolvedValue({ data: expectedResponse })
+
+      await driver.request(mockData)
+
+      // Verify that the default URL was used
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        ZarinpalUrls.REQUEST,
+        expect.any(Object),
+        expect.any(Object)
+      )
+    })
+
+    it('should use custom domain for sandbox environment', async () => {
+      const customDomain = 'api.example.com'
+      driver.setCustomDomain(customDomain)
+
+      const mockData: TransactionCreateInputZp = {
+        amount: 1000,
+        description: 'Test transaction',
+        callback_url: 'https://example.com/callback'
+      }
+
+      const expectedResponse: any = {
+        data: {
+          code: 1000,
+          message: '',
+          fee: 100,
+          url: '',
+          authority: 'xx',
+          fee_type: ''
+        },
+        errors: {
+          code: 0,
+          message: 'Transaction created successfully',
+          validations: []
+        },
+        isError: false
+      }
+
+      mockedAxios.post.mockResolvedValue({ data: expectedResponse })
+
+      await driver.request(mockData, true) // Enable sandbox
+
+      // Verify that the custom domain URL was used (with sandbox path)
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'https://api.example.com/pg/v4/payment/request.json',
+        expect.any(Object),
+        expect.any(Object)
+      )
+    })
   })
 })


### PR DESCRIPTION
This update introduces the ability to set a custom domain for ZarinPal API requests. A new method, setCustomDomain, has been added to allow users to specify a custom domain, which will be used for API calls and payment page URLs. The implementation includes input validation to ensure the domain is correctly formatted.

Additionally, tests have been added to verify the functionality of the custom domain feature, including setting the domain, cleaning the input, and ensuring fallback to default URLs when no custom domain is provided. This enhancement improves flexibility for users integrating with the ZarinPal service.